### PR TITLE
Implemented pump cycling time limiter

### DIFF
--- a/Software/code/watercontrol.py
+++ b/Software/code/watercontrol.py
@@ -125,7 +125,7 @@ def pumprefillcycle():
         samplerate = (1/32) # Seconds
         s1.value = True
         sleep(2)
-
+        pumprefillcycle_timestart = monotonic(); #The start time recorded using monotonic clock
         while s1.value == True: # If MOSFET S1 is enabled
 
             #Debug message
@@ -133,7 +133,6 @@ def pumprefillcycle():
 
             Amps = ina.current # Measured in milliamps
             A_filtered = currentFilter.update(Amps) # Filtered Current measured in milliamps
-            pumprefillcycle_timestart = monotonic(); #The start time recorded using monotonic clock 
             pumprefillcycle_timediff = monotonic() - pumprefillcycle_timestart #Calculate time difference
             #Debug message
             print(f"watercontrol-pumprefillcycle: Time elapsed = {pumprefillcycle_timediff} seconds") if debugstate == 1 or debugstate == 2 else None


### PR DESCRIPTION
### Desciption
A description of the pull requests including:
- Implemented time limit in pumprefillcycle() using monotonic clock and conditional ifs statement.
- Ensure the pump cycling when the pump is out of water is limited in time to 10s so it will not run indefinitely and fails into no water if time limit exceeded.

### Resolves
- fix #92 

### Checklist before PR submission
Please acknowledge these statements by adding x to the brackes as [x]:
- [x] The code has been self-reviewed and tested to be working.
- [x] The changes contained in this submission are authorized by the rights holder to be licensed in accordance with the repository licensing scheme.
