### PR TITLE
Adds function that regularly generate wind for 45 seconds every other hours.

### DIFF
--- a/Software/code/mainflags
+++ b/Software/code/mainflags
@@ -9,3 +9,4 @@ EverySUNSET,0
 PumpRunDry,0
 PumpACTIVE,0
 DebugState,0
+WindCadence,0


### PR DESCRIPTION
### Desciption
Adds code too XX15 routine that checks if the fan was already on from temp/rh exceeding limit. If not if will turns fan on for 45 seconds every other hour using if statement and permanent memory using mainflags to create regular wind.

### Resolves
- fix #111 

### Additional information

### Checklist before PR submission
Please acknowledge these statements by adding x to the brackes as [x]:
- [x] The code has been self-reviewed and tested to be working.
- [x] The changes contained in this submission are authorized by the rights holder to be licensed in accordance with the repository licensing scheme.
